### PR TITLE
add Dockerfile for ROS 2 Lyrical (Ubuntu 26.04 / L4T 39.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This Dockerfile is based on [nvidia/container-images/l4t-base](https://gitlab.co
 
 ## Requirements
 
-- Jetson Linux 36.4 <https://developer.nvidia.com/embedded/jetson-linux-r3640>
+- Jetson Linux 36.4 <https://developer.nvidia.com/embedded/jetson-linux-r3640> (`humble`, `jazzy`)
   - JetPack 6.1 <https://developer.nvidia.com/embedded/jetpack-sdk-61>
+- Jetson Linux 39.2 <https://developer.nvidia.com/embedded/jetson-linux> (`lyrical`)
+  - JetPack 7.2 <https://developer.nvidia.com/embedded/jetpack>
 - Docker
 - NVIDIA Container Toolkit
 
@@ -18,6 +20,7 @@ This Dockerfile is based on [nvidia/container-images/l4t-base](https://gitlab.co
 |---|---|---|
 |36.4.0|Humble|[humble/Dockerfile](humble/Dockerfile)|
 |36.4.0|Jazzy|[jazzy/Dockerfile](jazzy/Dockerfile)|
+|39.2.0|Lyrical|[lyrical/Dockerfile](lyrical/Dockerfile)|
 
 ## Checked applications
 
@@ -56,3 +59,4 @@ $ ros2 run demo_nodes_py listener
 - <https://gitlab.com/nvidia/container-images/l4t-base>
 - <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html>
 - <https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html>
+- <https://docs.ros.org/en/lyrical/Get-Started/Installation/Ubuntu-Install-Debs.html>

--- a/lyrical/Dockerfile
+++ b/lyrical/Dockerfile
@@ -1,0 +1,163 @@
+FROM docker.io/arm64v8/ubuntu:26.04
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES all
+
+ARG UID=1000
+ARG GID=1000
+
+# add new sudo user
+ENV USERNAME jetson
+ENV HOME /home/$USERNAME
+
+# https://askubuntu.com/questions/1513927/ubuntu-24-04-docker-images-now-includes-user-ubuntu-with-uid-gid-1000
+RUN if getent passwd $UID; then \
+      userdel -f $(getent passwd $UID | cut -d: -f1); \
+    fi \
+    && if getent group $GID; then \
+      groupdel $(getent group $GID | cut -d: -f1); \
+    fi
+
+RUN useradd -m $USERNAME && \
+        echo "$USERNAME:$USERNAME" | chpasswd && \
+        usermod --shell /bin/bash $USERNAME && \
+        usermod -aG sudo $USERNAME && \
+        mkdir /etc/sudoers.d && \
+        echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
+        chmod 0440 /etc/sudoers.d/$USERNAME && \
+        usermod  --uid $UID $USERNAME && \
+        groupmod --gid $GID $USERNAME
+RUN gpasswd -a $USERNAME video
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -qq -y --no-install-recommends \
+        bash-completion \
+        bc \
+        build-essential \
+        bzip2 \
+        can-utils \
+        ca-certificates \
+        cmake \
+        command-not-found \
+        curl \
+        emacs \
+        freeglut3-dev \
+        git \
+        gnupg2 \
+        gstreamer1.0-alsa \
+        gstreamer1.0-libav \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-tools \
+        i2c-tools \
+        iproute2 \
+        iputils-ping \
+        iw \
+        kbd \
+        kmod \
+        language-pack-en-base \
+        libapt-pkg-dev \
+        libcanberra-gtk3-module \
+        libgles2 \
+        libglu1-mesa-dev \
+        libglvnd-dev \
+        libgtk-3-0t64 \
+        libudev1 \
+        libvulkan1 \
+        libzmq5 \
+        mesa-utils \
+        mtd-utils \
+        parted \
+        pciutils \
+        python3 \
+        python3-numpy \
+        python3-pexpect \
+        python3-pip \
+        sox \
+        sudo \
+        tmux \
+        udev \
+        vulkan-tools \
+        wget \
+        wpasupplicant \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# EGL
+RUN echo "/usr/lib/aarch64-linux-gnu/nvidia" >> /etc/ld.so.conf.d/nvidia-tegra.conf && \
+    echo "/usr/lib/aarch64-linux-gnu/tegra-egl" >> /etc/ld.so.conf.d/nvidia-tegra.conf
+RUN rm -rf /usr/share/glvnd/egl_vendor.d && \
+    mkdir -p /usr/share/glvnd/egl_vendor.d/ && echo '\
+{\
+    "file_format_version" : "1.0.0",\
+    "ICD" : {\
+        "library_path" : "libEGL_nvidia.so.0"\
+    }\
+}' > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+RUN mkdir -p /usr/share/egl/egl_external_platform.d/ && echo '\
+{\
+    "file_format_version" : "1.0.0",\
+    "ICD" : {\
+        "library_path" : "libnvidia-egl-wayland.so.1"\
+    }\
+}' > /usr/share/egl/egl_external_platform.d/nvidia_wayland.json
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/jetson-ota-public.gpg] https://repo.download.nvidia.com/jetson/common r39.2 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/jetson-ota-public.gpg] https://repo.download.nvidia.com/jetson/som r39.2 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/jetson-ota-public.gpg] https://repo.download.nvidia.com/jetson/ffmpeg r39.2 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+RUN wget -O /etc/jetson-ota-public.key https://gitlab.com/nvidia/container-images/l4t-base/-/raw/master/jetson-ota-public.key && \
+    cat /etc/jetson-ota-public.key | gpg --dearmor -o /usr/share/keyrings/jetson-ota-public.gpg
+
+# CUDA, cuDNN
+# NOTE: use cuda-toolkit instead of the `cuda` metapackage, which pulls in
+#       nvidia-driver-open. The driver is mounted from the host by the NVIDIA runtime.
+RUN apt-get update && \
+    apt-get install -qq -y --no-install-recommends \
+        cuda-toolkit \
+        libcudnn9-cuda-13 \
+        libcudnn9-dev-cuda-13 \
+        libcudnn9-samples \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ldconfig
+
+# install ROS 2 Lyrical
+ARG ROS_APT_SOURCE_VERSION=1.2.0
+RUN curl -fsSL -o /tmp/ros2-apt-source.deb \
+        "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb" && \
+    dpkg -i /tmp/ros2-apt-source.deb && \
+    rm -f /tmp/ros2-apt-source.deb
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ros-lyrical-desktop \
+        ros-lyrical-rmw-cyclonedds-cpp \
+        ros-dev-tools \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install colcon and rosdep
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3-colcon-common-extensions \
+        python3-rosdep \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+USER $USERNAME
+WORKDIR /home/$USERNAME
+SHELL ["/bin/bash", "-l", "-c"]
+
+RUN echo "export PATH=/usr/local/cuda/bin:$PATH" >> ~/.bashrc && \
+    echo "export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH" >> ~/.bashrc
+
+# initialize rosdep
+RUN sudo rosdep init && \
+    rosdep update
+
+RUN echo "source /opt/ros/lyrical/setup.bash" >> ~/.bashrc

--- a/lyrical/README.md
+++ b/lyrical/README.md
@@ -1,0 +1,12 @@
+## Build docker image
+
+```bash
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t l4t-ros2:lyrical .
+```
+
+## Launch docker container
+
+```bash
+xhost +
+docker run -it --rm --net=host --runtime nvidia -e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix -v $HOME:$HOME l4t-ros2:lyrical bash
+```


### PR DESCRIPTION
`jazzy/Dockerfile` をベースに Ubuntu 26.04 + L4T 39.2 (JetPack 7) + ROS 2 Lyrical Luth 対応の `lyrical/` を追加しました。

## ROS 2 ディストリビューションについて

**ROS 2 Kilted Kaiju は Ubuntu 24.04 Noble のみが対象プラットフォーム**で、`packages.ros.org` の `resolute` (26.04) には Kilted のバイナリが 1 つも存在しません（存在するのは `lyrical` の 2559 パッケージのみ）。また Kilted は 2026年11月に EOL を迎えます。26.04 向けにリリースされている **Lyrical Luth** を採用しています。公式ドキュメントにも "ROS 2 Lyrical Luth is available for Ubuntu Resolute Raccoon (26.04)" と明記されています。

## Ubuntu 26.04 に伴う変更

- `wireless-tools` を削除（26.04 でパッケージが提供されなくなったため。`iw` は残存）
- `libgtk-3-0` → `libgtk-3-0t64`

## L4T 39.2 (JetPack 7) に伴う変更

atinfinity/l4t-base-docker#5 と同一の変更です。

- apt リポジトリ: `common` + `t234` @ r36.4 → `common` + `som` @ r39.2
- Tegra ライブラリパス: `/usr/lib/aarch64-linux-gnu/tegra` → `/usr/lib/aarch64-linux-gnu/nvidia`
- `cuda` → `cuda-toolkit`（`cuda` メタパッケージは `nvidia-driver-open` を引き込みますが、ドライバは NVIDIA runtime がホストからマウントするためコンテナ内には不要です）
- cuDNN: `libcudnn9` / `libcudnn9-dev` → `libcudnn9-cuda-13` / `libcudnn9-dev-cuda-13`

## ROS 2 Lyrical に伴う変更

- apt リポジトリの登録を `ros2-apt-source` パッケージ方式に変更（バージョンは `1.2.0` 固定）。従来の `ros.key` 手動取得 + `sources.list` 手書きは廃止。これに伴い `jazzy/Dockerfile` にあった root 環境下での `sudo tee` も不要になりました
- `ros-lyrical-desktop` / `ros-lyrical-rmw-cyclonedds-cpp` / `ros-dev-tools`
- `rosbag2-storage-mcap` は明示指定していません。`ros-lyrical-desktop` の依存として既に導入されており、記録時の既定フォーマットも mcap であることを確認済みです

## 動作確認

Jetson Orin NX 16GB / Jetson Linux 39.2.0 (JetPack 7.2.1) / NVIDIA driver 595.78 / X11 でビルドと実行を確認しました。

```
$ . /etc/os-release && echo $PRETTY_NAME
Ubuntu 26.04.1 LTS

$ nvcc --version
Cuda compilation tools, release 13.2, V13.2.86

$ glxinfo -B
direct rendering: Yes
OpenGL renderer string: NVIDIA Tegra Orin (nvgpu)/integrated
OpenGL core profile version string: 4.6.0 NVIDIA 595.78
```

```
[INFO] [1788969936.560511758] [talker]: Publishing: 'Hello World: 1'
[INFO] [1788969936.580013214] [listener]: I heard: [Hello World: 1]
```

turtlesim と RViz2 も X11 上で起動を確認しました（RViz2 は `OpenGl version: 4.6 (GLSL 4.6)`）。

## 補足（このPRでは未対応）

- Nav2 は `resolute` リポジトリに `ros-lyrical-navigation2` メタパッケージと `ros-lyrical-nav2-bringup` が無いため、今回の確認対象から外しています（`nav2-*` のコアパッケージ 35 個は存在）。README の Nav2 スクリーンショットは Humble / Jazzy 時点のものです
- `jazzy/Dockerfile` から引き継いだ既知の点として、`~/.bashrc` に CUDA の PATH を設定しているため非対話シェルでは `nvcc` に PATH が通りません。差分を Ubuntu 26.04 / L4T 39.2 / ROS 2 Lyrical の3点に限定するため、このPRでは修正していません
- イメージサイズは 19.9GB です

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKaYZgPYDzXtKCpKj7iu8r
